### PR TITLE
ajout block specifique download openjdk-17 pour centOS 7

### DIFF
--- a/java/tasks/java_runtime_item.yml
+++ b/java/tasks/java_runtime_item.yml
@@ -1,33 +1,34 @@
 - name: download and extract
   block:
-  - name: download {{ item.type }} {{ item.version }}
-    get_url:
-      url: "{{ _java_archive_url }}"
-      dest: "{{ _java_archive_destination }}"
-      checksum: "{{ _java_archive_checksum }}"
-      owner: "{{ _java_user }}"
-      group: "{{ _java_group }}"
-      headers: "Cookie: oraclelicense=accept-securebackup-cookie"
-
   - block:
-    - name: prepare {{ _java_install_destination }} folder
-      file:
-        path: "{{ _java_install_destination }}"
-        state: directory
-        mode: u=rwx,g=rwx,o=rx
+    - name: download {{ item.type }} {{ item.version }}
+      get_url:
+        url: "{{ _java_archive_url }}"
+        dest: "{{ _java_archive_destination }}"
+        checksum: "{{ _java_archive_checksum }}"
         owner: "{{ _java_user }}"
         group: "{{ _java_group }}"
+        headers: "Cookie: oraclelicense=accept-securebackup-cookie"
 
-    - name: install {{ item.type }} {{ item.version }}
-      unarchive:
-        remote_src: true
-        dest: "{{ _java_install_destination }}"
-        src: "{{ _java_archive_destination }}"
-        extra_opts:
-          - --strip-components=1
+    - block:
+      - name: prepare {{ _java_install_destination }} folder
+        file:
+          path: "{{ _java_install_destination }}"
+          state: directory
+          mode: u=rwx,g=rwx,o=rx
+          owner: "{{ _java_user }}"
+          group: "{{ _java_group }}"
 
-    when: ansible_distribution_major_version != "5"
-
+      - name: install {{ item.type }} {{ item.version }}
+        unarchive:
+          remote_src: true
+          dest: "{{ _java_install_destination }}"
+          src: "{{ _java_archive_destination }}"
+          extra_opts:
+            - --strip-components=1
+      when: ansible_distribution_major_version != "5"
+    when: not(ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" and _java_version|int >= 17)
+  
   # strip-components is not available in CentOS 5, we need a workaround
   # untar in _java_install_wa_destination
   # find parent of bin folder
@@ -66,6 +67,53 @@
 
     when: ansible_distribution_major_version == "5"
 
+  # java 17 is not available on CentOS 7. Download manually and install 
+  - block:
+    - name: download CentOS 7 {{ item.type }} {{ item.version }}
+      get_url:
+        url: "{{ _java17_archive_url }}"
+        dest: "{{ _java17_archive_destination }}"
+        checksum: "{{ _java_archive_checksum }}"
+        owner: "{{ _java_user }}"
+        group: "{{ _java_group }}"
+        # headers: "Cookie: oraclelicense=accept-securebackup-cookie"
+
+    - block:
+      - name: prepare CentOS 7 {{ _java17_install_destination }} folder
+        file:
+          path: "{{ _java17_install_destination }}"
+          state: directory
+          mode: u=rwx,g=rwx,o=rx
+          owner: "{{ _java_user }}"
+          group: "{{ _java_group }}"
+
+      - name: install CentOS 7 {{ item.type }} {{ item.version }}
+        unarchive:
+          remote_src: true
+          dest: "{{ _java17_install_destination }}"
+          src: "{{ _java17_archive_destination }}"
+          extra_opts:
+            - --strip-components=1
+
+      - name: find {{ item.type }} {{ item.version }}
+        command: "find {{ _java17_install_destination }} -maxdepth 2 -name bin -type d -exec dirname {} \\;"
+        register: find_result
+        changed_when: no
+        check_mode: no
+
+      - name: check find {{ item.type }} {{ item.version }}
+        file:
+          state: directory
+          path: "{{ find_result.stdout_lines[0] }}"
+
+      - name: symlink {{ item.type }} {{ item.version }}
+        file:
+          state: link
+          path: "{{ _java_install_destination }}"
+          src: "{{ find_result.stdout_lines[0] }}"
+
+    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" and _java_version|int >= 17
+
   - name: provide {{ item.type }} {{ item.version }} path
     set_fact:
       # update current var by combining with current value
@@ -82,11 +130,15 @@
   when: item.packaging is not defined or item.packaging == 'archive'
   vars:
     _java_archive_destination: "{{ _java_download_path }}/java-{{ item.type }}-{{ item.version }}-{{ item.arch }}.tar.gz"
+    _java17_archive_destination: "{{ _java_download_path }}/java-{{ item.version }}-{{ item.type }}-{{ item.fullversion }}-{{ item.arch }}.tar.gz"
     _java_archive_url: "{{ java_archive_url_template }}"
+    _java17_archive_url: "{{ item.url }}"
     _java_archive_checksum: "{{ item.checksum }}"
     _java_install_destination: "{{ _java_runtime_path }}/{{ item.type }}-{{ item.version }}-{{ item.arch }}"
+    _java17_install_destination: "{{ item.install_destination }}/java-{{ item.fullversion }}-{{ item.type }}-{{ item.arch }}"
     # used when unarchive with strip components is not available
     _java_install_wa_destination: "{{ _java_runtime_path }}/wa-{{ item.type }}-{{ item.version }}-{{ item.arch }}"
+    _java_version: "{{ item.version }}"
 
 - name: package
   block:


### PR DESCRIPTION
La version open-JDK 17 n'est pas disponible sur cent OS 7. On la télécharge et on install manuellement.
Le setenv pointe sur /data/opt/ pour les archives (historique ?). Un lien symboliqe est créé pour changer le nom de dossier et lier vers /data/opt/

Lien vers la MR côté fafcea : https://gitlab.tools.kobalt.fr/fafcea/fafcea-si-ansible/-/merge_requests/4